### PR TITLE
Add missing data we get from the REST API response

### DIFF
--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>

--- a/src/Bitbucket.Net/Models/Core/Projects/FromToRef.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/FromToRef.cs
@@ -3,6 +3,8 @@
     public class FromToRef
     {
         public string Id { get; set; }
+        public string DisplayId { get; set; }
+        public string LatestCommit { get; set; }
         public RepositoryRef Repository { get; set; }
     }
 }

--- a/src/Bitbucket.Net/Models/Core/Projects/Repository.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/Repository.cs
@@ -9,6 +9,7 @@
         public bool Forkable { get; set; }
         public bool Public { get; set; }
         public CloneLinks Links { get; set; }
+        public string DefaultBranch { get; set; }
 
         public override string ToString() => Name;
     }

--- a/test/Bitbucket.Net.Tests/Bitbucket.Net.Tests.csproj
+++ b/test/Bitbucket.Net.Tests/Bitbucket.Net.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <LangVersion>7</LangVersion>

--- a/test/Bitbucket.Net.Tests/BitbucketClientShould.cs
+++ b/test/Bitbucket.Net.Tests/BitbucketClientShould.cs
@@ -14,7 +14,7 @@ namespace Bitbucket.Net.Tests
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .Build();
 
-            _client = new BitbucketClient(configuration["url"], configuration["username"], configuration["password"]);
+            _client = new BitbucketClient(configuration["url"], configuration["username"], configuration["password"], false);
         }
     }
 }


### PR DESCRIPTION
For some bitbucket server versions we might get the default branch. For old ones, we don't.
We will get the latest commit sha in PRs regardless.
(Tested on version 6.10.13)