### PR TITLE
Move `Public` prop to the base `ProjectRef`

### DIFF
--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.0.9</Version>
+    <Version>1.0.11</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>

--- a/src/Bitbucket.Net/Models/Core/Projects/Project.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/Project.cs
@@ -3,7 +3,6 @@
     public class Project : ProjectDefinition
     {
         public int Id { get; set; }
-        public bool Public { get; set; }
         public string Type { get; set; }
         public Links Links { get; set; }
 

--- a/src/Bitbucket.Net/Models/Core/Projects/ProjectRef.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/ProjectRef.cs
@@ -5,5 +5,7 @@
         public string Key { get; set; }
         
         public string Id { get; set; }
+        
+        public bool Public { get; set; }
     }
 }


### PR DESCRIPTION
in order to consume the `project.public` from `Repository`.
the `Repository` holds a `ProjectRef` and not `Project` (though it seems to actually return something more similar to `Project` from the raw rest api).

I could change the `Repository` to hold `Project` instead, but it's being used all over, I wanted to add only this specific field and not the entire model as I'm not sure what is the wide effect of this change.

but I think for the long run, we should ditch this package completely and just implement our own rest-api client based on the bitbucketserver docs.

part of LIM-28721