### PR TITLE
Upgrade Flurl.Http from 3.0.1 to 4.0.2

### DIFF
--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.0.11</Version>
+    <Version>1.0.12-prerelease</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>
@@ -20,7 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flurl.Http" Version="3.0.1" />
+    <PackageReference Include="Flurl.Http" Version="4.0.2" />
+    <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>

--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.0.12-prerelease</Version>
+    <Version>1.1.0</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>

--- a/src/Bitbucket.Net/BitbucketClient.cs
+++ b/src/Bitbucket.Net/BitbucketClient.cs
@@ -8,7 +8,7 @@ using Bitbucket.Net.Common;
 using Bitbucket.Net.Common.Models;
 using Flurl;
 using Flurl.Http;
-using Flurl.Http.Configuration;
+using Flurl.Http.Newtonsoft;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -16,11 +16,11 @@ namespace Bitbucket.Net
 {
     public partial class BitbucketClient
     {
-        private static readonly ISerializer s_serializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings
+        private static readonly JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-        });
+        };
 
         static BitbucketClient()
         {
@@ -60,9 +60,13 @@ namespace Bitbucket.Net
 
             var httpClient = new HttpClient(httpClientHandler);
             var flurlClient = new FlurlClient(httpClient);
-            flurlClient.Settings.Redirects.Enabled = true;
-            flurlClient.Settings.Redirects.ForwardAuthorizationHeader = true;
-            flurlClient.Settings.Redirects.AllowSecureToInsecure = true;
+            flurlClient.WithSettings(s =>
+            {
+                s.Redirects.Enabled = true;
+                s.Redirects.ForwardAuthorizationHeader = true;
+                s.Redirects.AllowSecureToInsecure = true;
+                s.JsonSerializer = new NewtonsoftJsonSerializer(s_jsonSettings);
+            });
 
             return new BitbucketClient(url, flurlClient, userName, password, getToken);
         }
@@ -82,13 +86,12 @@ namespace Bitbucket.Net
         private IFlurlRequest GetRequest(Url url)
         {
             return _flurlClient.Request(url)
-                .ConfigureRequest(settings => settings.JsonSerializer = s_serializer)
                 .WithAuthentication(_getToken, _userName, _password);
         }
 
         private async Task<TResult> ReadResponseContentAsync<TResult>(IFlurlResponse responseMessage, Func<string, TResult> contentHandler = null)
         {
-            string content = await responseMessage.GetJsonAsync().ConfigureAwait(false);
+            string content = await responseMessage.GetStringAsync().ConfigureAwait(false);
             return contentHandler != null
                 ? contentHandler(content)
                 : JsonConvert.DeserializeObject<TResult>(content);

--- a/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
@@ -82,11 +82,9 @@ namespace Bitbucket.Net
 
         public async Task<Project> GetProjectAsync(string projectKey)
         {
-            var response = await GetProjectsUrl($"/{projectKey}")
-                .GetJsonAsync()
+            return await GetProjectsUrl($"/{projectKey}")
+                .GetJsonAsync<Project>()
                 .ConfigureAwait(false);
-
-            return await HandleResponseAsync<Project>(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<UserPermission>> GetProjectUserPermissionsAsync(string projectKey, string filter = null,

--- a/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
@@ -82,9 +82,11 @@ namespace Bitbucket.Net
 
         public async Task<Project> GetProjectAsync(string projectKey)
         {
-            return await GetProjectsUrl($"/{projectKey}")
-                .GetJsonAsync<Project>()
+            var response = await GetProjectsUrl($"/{projectKey}")
+                .GetAsync()
                 .ConfigureAwait(false);
+
+            return await HandleResponseAsync<Project>(response).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<UserPermission>> GetProjectUserPermissionsAsync(string projectKey, string filter = null,


### PR DESCRIPTION
## Summary
- Upgrade `Flurl.Http` from 3.0.1 to 4.0.2
- Add `Flurl.Http.Newtonsoft` (0.9.1) companion package to preserve Newtonsoft.Json serialization
- Adapt to Flurl.Http 4.x breaking changes:
  - Configure serializer + redirect settings at the `FlurlClient` level via `WithSettings` (replaces per-request `ConfigureRequest` and direct `Settings` property writes)
  - Replace removed non-generic `GetJsonAsync()` calls with `GetStringAsync()` / `GetJsonAsync<T>()`
- Bump package version to 1.0.12

## Note
`CreateWithCustomClient` is unchanged — callers providing their own `FlurlClient` are responsible for configuring Newtonsoft serialization on their side (relevant for the LIM repo consumer).

## Test plan
- [x] Solution builds successfully (`dotnet build`)
- [ ] Verify at runtime against a Bitbucket Server instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)