### PR TITLE
Add Archived to Core Projects Repository model

### DIFF
--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>

--- a/src/Bitbucket.Net/Models/Core/Projects/Repository.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/Repository.cs
@@ -8,6 +8,7 @@
         public string StatusMessage { get; set; }
         public bool Forkable { get; set; }
         public bool Public { get; set; }
+        public bool Archived { get; set; }
         public CloneLinks Links { get; set; }
         public string DefaultBranch { get; set; }
 


### PR DESCRIPTION
## Summary
- The Bitbucket Server REST API returns an `archived` boolean on repositories (`GET /rest/api/1.0/projects/{projectKey}/repos`), but the `Repository` model didn't expose it — so the field is silently dropped on deserialization and consumers can't read archive status.
- Adds `public bool Archived { get; set; }` to `Models/Core/Projects/Repository.cs`, deserialized from `archived` via the existing camelCase convention (matches `Forkable`/`Public`/`DefaultBranch`, no `[JsonProperty]` needed).

## Why
Apiiro LIM (LIM-41148) needs Bitbucket Server repo archive status to auto-unmonitor archived repos; today it can't because this client drops the field. The other providers (GitHub/GitLab/AzureDevops) already surface archive status.

## Test plan
- `dotnet build` — clean (0 errors).
- Additive, backward-compatible; defaults to `false` when the field is absent.

Note: a new package release is needed so downstream (lim) can bump the pin and wire `IsArchived = repository.Archived` in `BitbucketServerProvider.TransformRepository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)