### PR TITLE
Remove process-global JsonConvert.DefaultSettings mutation

### DIFF
--- a/src/Bitbucket.Net/Bitbucket.Net.csproj
+++ b/src/Bitbucket.Net/Bitbucket.Net.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Apiiro.Bitbucket.Net</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <Product>Bitbucket.Net</Product>

--- a/src/Bitbucket.Net/BitbucketClient.cs
+++ b/src/Bitbucket.Net/BitbucketClient.cs
@@ -16,20 +16,11 @@ namespace Bitbucket.Net
 {
     public partial class BitbucketClient
     {
-        private static readonly JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings
+        internal static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
         };
-
-        static BitbucketClient()
-        {
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-            };
-        }
 
         private readonly Url _url;
         private readonly Func<string> _getToken;
@@ -65,7 +56,7 @@ namespace Bitbucket.Net
                 s.Redirects.Enabled = true;
                 s.Redirects.ForwardAuthorizationHeader = true;
                 s.Redirects.AllowSecureToInsecure = true;
-                s.JsonSerializer = new NewtonsoftJsonSerializer(s_jsonSettings);
+                s.JsonSerializer = new NewtonsoftJsonSerializer(SerializerSettings);
             });
 
             return new BitbucketClient(url, flurlClient, userName, password, getToken);
@@ -94,7 +85,7 @@ namespace Bitbucket.Net
             string content = await responseMessage.GetStringAsync().ConfigureAwait(false);
             return contentHandler != null
                 ? contentHandler(content)
-                : JsonConvert.DeserializeObject<TResult>(content);
+                : JsonConvert.DeserializeObject<TResult>(content, SerializerSettings);
         }
 
         private async Task<bool> ReadResponseContentAsync(IFlurlResponse responseMessage)

--- a/src/Bitbucket.Net/Branches/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Branches/BitbucketClient.cs
@@ -69,7 +69,7 @@ namespace Bitbucket.Net
 
             var response = await GetBranchUrl($"/projects/{projectKey}/repos/{repositorySlug}/branches")
                 .WithHeader("Content-Type", "application/json")
-                .SendAsync(HttpMethod.Delete, new StringContent(JsonConvert.SerializeObject(data)))
+                .SendAsync(HttpMethod.Delete, new StringContent(JsonConvert.SerializeObject(data, SerializerSettings)))
                 .ConfigureAwait(false);
 
             return await HandleResponseAsync(response).ConfigureAwait(false);

--- a/src/Bitbucket.Net/Models/Core/Projects/Branch.cs
+++ b/src/Bitbucket.Net/Models/Core/Projects/Branch.cs
@@ -30,15 +30,15 @@ namespace Bitbucket.Net.Models.Core.Projects
                 {
                     if (metadata.Name.ToString() == "com.atlassian.bitbucket.server.bitbucket-branch:ahead-behind-metadata-provider")
                     {
-                        _branchMetadata.AheadBehind = JsonConvert.DeserializeObject<AheadBehindMetaData>(metadata.Value.ToString());
+                        _branchMetadata.AheadBehind = JsonConvert.DeserializeObject<AheadBehindMetaData>(metadata.Value.ToString(), BitbucketClient.SerializerSettings);
                     }
                     else if (metadata.Name.ToString() == "com.atlassian.bitbucket.server.bitbucket-build:build-status-metadata")
                     {
-                        _branchMetadata.BuildStatus = JsonConvert.DeserializeObject<BuildStatusMetadata>(metadata.Value.ToString());
+                        _branchMetadata.BuildStatus = JsonConvert.DeserializeObject<BuildStatusMetadata>(metadata.Value.ToString(), BitbucketClient.SerializerSettings);
                     }
                     else if (metadata.Name.ToString() == "com.atlassian.bitbucket.server.bitbucket-ref-metadata:outgoing-pull-request-metadata")
                     {
-                        _branchMetadata.OutgoingPullRequest = JsonConvert.DeserializeObject<PullRequestMetadata>(metadata.Value.ToString());
+                        _branchMetadata.OutgoingPullRequest = JsonConvert.DeserializeObject<PullRequestMetadata>(metadata.Value.ToString(), BitbucketClient.SerializerSettings);
                     }
                 }
 

--- a/src/Bitbucket.Net/Ssh/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Ssh/BitbucketClient.cs
@@ -27,7 +27,7 @@ namespace Bitbucket.Net
         {
             var response =  await GetKeysUrl($"/ssh/{keyId}")
                 .WithHeader("Content-Type", "application/json")
-                .SendAsync(HttpMethod.Delete, new StringContent(JsonConvert.SerializeObject(projectsOrRepos)))
+                .SendAsync(HttpMethod.Delete, new StringContent(JsonConvert.SerializeObject(projectsOrRepos, SerializerSettings)))
                 .ConfigureAwait(false);
 
             return await HandleResponseAsync(response).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

`static BitbucketClient()` sets the **process-global** `JsonConvert.DefaultSettings`:

```csharp
JsonConvert.DefaultSettings = () => new JsonSerializerSettings
{
    ContractResolver = new CamelCasePropertyNamesContractResolver(),
    NullValueHandling = NullValueHandling.Ignore
};
```

It fires the first time anything touches `BitbucketClient`, and from then on it is the default for the **entire process**. `JsonConvert.SerializeObject(value, settings)` overlays a caller's settings on top of this global via `JsonSerializer.CreateDefault`, so any field a caller leaves unset (e.g. `NullValueHandling`) silently inherits these values.

**Blast radius:** any consumer that does Newtonsoft serialization with partial/default settings in the same process gets camelCase + `NullValueHandling.Ignore`. In Apiiro's `lim`, the `ConsumablesSyncer` service constructs a `BitbucketClient` (repo enrichers) and also serializes Qualys requests via Refit; after the client loaded, Qualys request bodies dropped a `null` field and no longer matched their recorded EasyVCR cassettes. The casing change is usually masked (explicit resolvers override it) and dropped nulls are benign for most APIs, so it stayed latent — exactly the kind of action-at-a-distance a library should never impose.

## Fix

Make the library self-contained instead of mutating global state:

- Delete the `static BitbucketClient()` constructor.
- Expose the existing settings as `internal static readonly SerializerSettings` (was the `private static s_jsonSettings`).
- Pass `SerializerSettings` explicitly to the library's bare `JsonConvert` calls:
  - typed deserialize in `ReadResponseContentAsync` (`BitbucketClient.cs`),
  - the three branch-metadata deserializes (`Models/Core/Projects/Branch.cs`),
  - serialize in `Ssh` and `Branches` delete payloads.
- The per-instance Flurl serializer already used these settings (`CreateWithDefaultClient`), so the wire behavior of `GetJsonAsync`/`PostJsonAsync` is unchanged.

`DeserializeObject<dynamic>(...)` calls (Inbox / Markup / Logs / Projects permission check) are intentionally left unchanged — they read literal `JObject` keys and are contract-resolver independent.

Version bumped `1.2.0` → `1.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of: LIM-41898 — https://apiiro.atlassian.net/browse/LIM-41898
